### PR TITLE
fix invalid numberOfColumns

### DIFF
--- a/Tangram/Source/Core/TangramView.m
+++ b/Tangram/Source/Core/TangramView.m
@@ -13,6 +13,7 @@
 #import "TangramEvent.h"
 #import "TangramContext.h"
 #import "TangramSafeMethod.h"
+#import "TangramFlowLayout.h"
 
 @interface TangramViewDelegateHandler : NSObject<TangramViewDelegate>
 
@@ -410,6 +411,14 @@
         for (int i=0; i< numberOfLayouts; i++) {
             NSString *layoutKey = [NSString stringWithFormat:@"%d", i];
             UIView<TangramLayoutProtocol> *layout = [self.clDataSource layoutInTangramView:self atIndex:i];
+            if ([layout isKindOfClass:[TangramFlowLayout class]]) {
+                if(((TangramFlowLayout *)layout).numberOfColumns <= 0) {
+#ifdef DEBUG
+                    NSLog(@"[TangramView] reloadData : Invalid data errors for layout.numberOfColumns at index, index is %d",i);
+#endif
+                    ((TangramFlowLayout *)layout).numberOfColumns = 1;
+                }
+            }
             [self.layoutDict tgrm_setObjectCheck:layout forKey:layoutKey];
             [self.layoutKeyArray tgrm_addObjectCheck:layoutKey];
             NSUInteger numberOfItemsInLayout = [self.clDataSource numberOfItemsInTangramView:self forLayout:layout];

--- a/Tangram/Source/Layouts/TangramFlowLayout.m
+++ b/Tangram/Source/Layouts/TangramFlowLayout.m
@@ -240,7 +240,18 @@
         }
     }
     NSObject<TangramItemModelProtocol> *lastItemModel = nil;
-    NSUInteger maxRows = (numberWithColspan < self.numberOfColumns) ? 1 : ceilf((CGFloat)(numberWithColspan - blockRows)/ self.numberOfColumns);
+    NSUInteger maxRows = 0;
+    if (numberWithColspan < self.numberOfColumns) {
+        maxRows = 1;
+    } else {
+        if (self.numberOfColumns <= 0) {
+#ifdef DEBUG
+            NSLog(@"[TangramFlowLayout] calculateLayout : Invalid data errors for self.numberOfColumns: %d",self.numberOfColumns);
+#endif
+            self.numberOfColumns = 1;
+        }
+        maxRows = ceilf((CGFloat)(numberWithColspan - blockRows) / self.numberOfColumns);
+    }
     
     maxRows += blockRows;
     NSUInteger columns = self.numberOfColumns;

--- a/TangramDemo/TangramDemo/EntryTableViewController.m
+++ b/TangramDemo/TangramDemo/EntryTableViewController.m
@@ -59,6 +59,7 @@
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    [tableView deselectRowAtIndexPath:indexPath animated:YES];
      //NSDictionary *dict = [self.testArray objectAtIndex:indexPath.row];
     //NSString *controllerName = [dict objectForKey:@"entry"];
     if (indexPath.row == 0) {


### PR DESCRIPTION
有时 这个layout.numberOfColumns 会存在 为0的情况.
`layout.numberOfColumns = index % 5;`

在模拟器中运行, 编译器会将+Inf的NSUInteger优化为0, 所以这时只会存在某些色块不显示的问题,但不会存在阻塞的问题.
![image](https://cloud.githubusercontent.com/assets/16211378/24737676/01799402-1ac3-11e7-9aea-db9bc8db9f2d.png)

但是在真机(arm64)中运行, 编译器并不会将+Inf的NSUInteger优化为0
![image](https://cloud.githubusercontent.com/assets/16211378/24737973/0f52c2d6-1ac5-11e7-87b2-78e048906698.png)


以至于接下来的for循环会执行很大的次数导致阻塞

