### PR TITLE
修改浮动和吸顶随屏幕滚动时跳动问题

### DIFF
--- a/Tangram/Core/TangramView.m
+++ b/Tangram/Core/TangramView.m
@@ -738,6 +738,7 @@
 
 - (void)setContentOffset:(CGPoint)contentOffset
 {
+    [super setContentOffset: contentOffset];
     NSUInteger min = [self layoutIndexByHeight:self.contentOffset.y];
     NSUInteger max = [self layoutIndexByHeight:self.contentOffset.y + self.vv_height];
     [self.visibleLayoutIdentifierSet removeAllObjects];


### PR DESCRIPTION
添加setContentOffset的父类调用，避免浮动和吸顶布局的抖动。