### PR TITLE
Fix issues for fix-layout, sticky-layout, floating-layout and width calculation

### DIFF
--- a/Tangram/Core/TangramView.m
+++ b/Tangram/Core/TangramView.m
@@ -811,7 +811,7 @@
         if (((TangramStickyLayout *)layout).stickyBottom == NO
             && self.contentOffset.y >= ((TangramStickyLayout *)layout).originalY - topOffset - ((TangramStickyLayout *)layout).extraOffset) {
             ((TangramStickyLayout *)layout).enterFloatStatus = YES;
-            layout.frame = CGRectMake(layout.frame.origin.x,self.contentOffset.y + topOffset + layout.marginTop + ((TangramStickyLayout *)layout).extraOffset , layout.frame.size.width, layout.frame.size.height);
+            layout.frame = CGRectMake(layout.frame.origin.x, contentOffset.y + topOffset + layout.marginTop + ((TangramStickyLayout *)layout).extraOffset , layout.frame.size.width, layout.frame.size.height);
             topOffset += (layout.vv_height + layout.marginTop + layout.marginBottom + ((TangramStickyLayout *)layout).extraOffset) ;
         }
         //吸底判断
@@ -819,7 +819,7 @@
                 && self.contentOffset.y + self.vv_height >= ((TangramStickyLayout *)layout).originalY + layout.vv_height)
         {
             ((TangramStickyLayout *)layout).enterFloatStatus = YES;
-            layout.frame = CGRectMake(layout.frame.origin.x,self.contentOffset.y + self.vv_height - layout.vv_height - layout.marginBottom, layout.frame.size.width, layout.frame.size.height);
+            layout.frame = CGRectMake(layout.frame.origin.x, contentOffset.y + self.vv_height - layout.vv_height - layout.marginBottom, layout.frame.size.width, layout.frame.size.height);
             bottomOffset -= (layout.vv_height + layout.marginTop + layout.marginBottom);
         }
         else
@@ -829,7 +829,7 @@
         }
     }
     for (UIView<TangramLayoutProtocol> *layout in self.dragableLayoutArray) {
-        layout.frame = CGRectMake(layout.frame.origin.x, ((TangramDragableLayout *)layout).originPoint.y + self.contentOffset.y , layout.frame.size.width, layout.frame.size.height);
+        layout.frame = CGRectMake(layout.frame.origin.x, ((TangramDragableLayout *)layout).originPoint.y + contentOffset.y , layout.frame.size.width, layout.frame.size.height);
     }
     
     [super setContentOffset:contentOffset];

--- a/Tangram/Core/TangramView.m
+++ b/Tangram/Core/TangramView.m
@@ -793,13 +793,13 @@
         }
         if ([layout.position isEqualToString:@"top-fixed"] ||
             (([layout.position isEqualToString:@"fixed"]) && (((TangramFixLayout *)layout).alignType == TopLeft || ((TangramFixLayout *)layout).alignType == TopRight))) {
-            layout.frame = CGRectMake(layout.frame.origin.x,self.contentOffset.y + ((TangramFixLayout *)layout).originPoint.y, layout.frame.size.width, layout.frame.size.height);
+            layout.frame = CGRectMake(layout.frame.origin.x, contentOffset.y + ((TangramFixLayout *)layout).originPoint.y, layout.frame.size.width, layout.frame.size.height);
             if (topOffset < layout.vv_height + ((TangramFixLayout *)layout).originPoint.y) {
                 topOffset = layout.vv_height + ((TangramFixLayout *)layout).originPoint.y;
             }
         }
         else {
-            layout.frame = CGRectMake(layout.frame.origin.x,self.vv_height- layout.vv_height + self.contentOffset.y -  ((TangramFixLayout *)layout).offsetY, layout.frame.size.width, layout.frame.size.height);
+            layout.frame = CGRectMake(layout.frame.origin.x,self.vv_height- layout.vv_height + contentOffset.y -  ((TangramFixLayout *)layout).offsetY, layout.frame.size.width, layout.frame.size.height);
             bottomOffset -= (layout.vv_height + ((TangramFixLayout *)layout).offsetY);
             if (bottomOffset > (self.vv_height - layout.vv_height - ((TangramFixLayout *)layout).offsetY)) {
                 bottomOffset  = (self.vv_height - layout.vv_height - ((TangramFixLayout *)layout).offsetY);

--- a/Tangram/Factory/TangramDefaultItemModelFactory.m
+++ b/Tangram/Factory/TangramDefaultItemModelFactory.m
@@ -83,17 +83,17 @@
         }
     }
     if ([styleDict tm_safeObjectForKey:@"width"] != nil) {
-        if([[styleDict tm_stringForKey:@"width"]containsString:@"rp"]){
+        NSString *widthStr = [styleDict tm_stringForKey:@"width"];
+        if([widthStr containsString:@"rp"]){
             itemModel.heightFromStyle = [TangramDefaultDataSourceHelper floatValueByRPObject:[styleDict tm_safeObjectForKey:@"width"]];
-        }
-        else{
+        } else if ([widthStr isEqualToString:@"-1"]) {
+            //width 配-1 意味着屏幕宽度
+            itemModel.widthFromStyle = [UIScreen mainScreen].bounds.size.width;
+        } else {
             itemModel.widthFromStyle = [styleDict tm_floatForKey:@"width"];
         }
     }
-    else if ([[styleDict tm_stringForKey:@"width"] isEqualToString:@"-1"]) {
-        //width 配-1 意味着屏幕宽度
-        itemModel.widthFromStyle = [UIScreen mainScreen].bounds.size.width;
-    }
+
     if ([styleDict tm_floatForKey:@"aspectRatio"] > 0.f) {
         itemModel.modelAspectRatio  = [styleDict tm_floatForKey:@"aspectRatio"];
     }

--- a/TangramDemo/TangramDemo/Resources/TangramMock.json
+++ b/TangramDemo/TangramDemo/Resources/TangramMock.json
@@ -37,6 +37,26 @@
                 ]
             },
             {
+                "type": "container-fix",
+                "id": "fix-RYYYYYYYYYY",
+                "style":{
+                    "bgColor": "#4dCC0000",
+                    "align": "top_left",
+                    "x": 0,
+                    "y": 55
+                },
+                "items": [
+                    {
+                        "type": "text",
+                        "text": "RYYYYYYYYYY",
+                        "style":{
+                           "width": "-1",
+                           "height": 20,
+                        }
+                    }
+                ]
+            },
+            {
                 "type": "container-oneColumn",
                 "id": "first-line-1",
                 "items": [

--- a/TangramDemo/TangramDemo/Resources/TangramMock.json
+++ b/TangramDemo/TangramDemo/Resources/TangramMock.json
@@ -37,18 +37,58 @@
                 ]
             },
             {
+                "type": "container-float",
+                "id": "float-RYYYYYYYYYY",
+                "style":{
+                    "bgColor": "#CC5500",
+                    "align": "bottom_left",
+                    "x": 20,
+                    "y": 20
+                },
+                "items": [
+                    {
+                        "type": "text",
+                        "text": "float-layout",
+                        "style":{
+                           "width":  40,
+                           "height": 40,
+                        }
+                    }
+                ]
+            },
+            {
+                "type": "container-sticky",
+                "id": "sticky-RYYYYYYYYYY",
+                "style":{
+                    "bgColor": "#CC5500",
+                    "align": "top_left",
+                    "x": 0,
+                    "y": 80
+                },
+                "items": [
+                    {
+                        "type": "text",
+                        "text": "sticky-layout",
+                        "style":{
+                           "width":  100,
+                           "height": 20,
+                        }
+                    }
+                ]
+            },
+            {
                 "type": "container-fix",
                 "id": "fix-RYYYYYYYYYY",
                 "style":{
                     "bgColor": "#4dCC0000",
                     "align": "top_left",
                     "x": 0,
-                    "y": 55
+                    "y": 100
                 },
                 "items": [
                     {
                         "type": "text",
-                        "text": "RYYYYYYYYYY",
+                        "text": "fix layout",
                         "style":{
                            "width": "-1",
                            "height": 20,


### PR DESCRIPTION
## Fix issues:  
 1.  support define width as -1; as it is equal to the width of the screen
 2. views with fix-layout, sticky layout or floating layout should stay sticky on the screen when scrolling3

## Before Fixing: 

### Fix Layout 
When scrolling, the view in red keep shaking and won't be sticky on the screen. 
![ezgif com-gif-maker](https://user-images.githubusercontent.com/7471672/119767550-9c11c600-bee9-11eb-86b4-8fa65ae3ef40.gif)

### Sticky layout 

The view with sticky layout keeps jumping 

![stiky-before](https://user-images.githubusercontent.com/7471672/119845747-1d924400-bf3c-11eb-944c-0582754278bd.gif)

### Floating layout 
Floating view can stay where it should be steadily 
 
![floating-layout](https://user-images.githubusercontent.com/7471672/119845892-3b5fa900-bf3c-11eb-91f6-e19a44b40c6f.gif)


## After fixing: 

Views with these 3 layouts stay stickily on the screen when scrolling 

![fix](https://user-images.githubusercontent.com/7471672/119845948-49152e80-bf3c-11eb-8a92-640b4f4ce840.gif)

